### PR TITLE
Fix devnet and move to args token info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,25 @@
+# ESDT create
 ## About
 Create new ESDT using erdpy commands.
 
-## Problems
-- Only works on testnet, but not work on devnet
-On devnet, 400 - Bad Request Error occurred.
+## How to
+### Create PEM
+First you will need to create a wallet.pem file. To do so, you need to go on the network wallet of you choice (testnet, devnet, mainnet) and create a wallet. Keep the pass mnemonic.
+
+Then you can call the following command to generate the .pem file:
+
+```sh
+erdpy wallet derive --mnemonic wallet/devnet/devnet-wallet.pem 
+```
+
+### Running
+Now you can run the script with the following arguement.
+Make sure you don't have any space of special character in the TOKEN_NAME & TOKEN_TICKER. 
+```sh
+sh ./create-new-token.sh <NETWORK> <TOKEN_NAME> <TOKEN_TICKER>
+```
+
+Running with python:
+```py
+python3 create-new-token.py -net <NETWORK> -tn <TOKEN_NAME> -tt <TOKEN_TICKER>
+```

--- a/create-new-token.py
+++ b/create-new-token.py
@@ -3,15 +3,8 @@ import subprocess
 import ast
 import json
 import time
+import argparse
 
-
-OWNER_PEMFILE = "./wallet/testnet/testnet-wallet.pem"
-PROXY_URL = "https://testnet-api.elrond.com"
-GATEWAY_URL = "https://testnet-gateway.elrond.com"
-
-# OWNER_PEMFILE = "./wallet/devnet/devnet-wallet.pem"
-# PROXY_URL = "https://devnet-api.elrond.com"
-# GATEWAY_URL = "https://devnet-gateway.elrond.com"
 
 ESDT_ISSUE_ADDRESS = "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u"
 
@@ -24,17 +17,18 @@ ESDT_ISSUE_ADDRESS = "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a
 # Smart: @canFreeze@true@canWipe@true@canPause@true@canMint@true@canBurn@true@canUpgrade@true
 # Raw: @63616e467265657a65@74727565@63616e57697065@74727565@63616e5061757365@74727565@63616e4d696e74@74727565@63616e4275726e@74727565@63616e55706772616465@74727565
 
-def IssueTokenTransaction():
+def IssueTokenTransaction(name, ticker):
     data = "issue"
-    data += "@536e6f77466c616b65"   # token name: "SnowFlake"
-    data += "@534643"               # token ticker: "SFC"
-    data += "@d3c21bcecceda1000000" # initial supply: 1e24 wei - 1e6 $ESDT
-    data += "@12"                   # number of decimals: 18
+    data += f"@{name.encode('utf-8').hex()}"    # token name
+    data += f"@{ticker.upper().encode('utf-8').hex()}"  # token ticker
+    data += "@d3c21bcecceda1000000"             # initial supply: 1e24 wei - 1e6 $ESDT
+    data += "@12"                               # number of decimals: 18
     data += "@63616e467265657a65@74727565@63616e57697065@74727565@63616e5061757365@74727565@63616e4d696e74@74727565@63616e4275726e@74727565@63616e55706772616465@74727565"
 
     command = "erdpy tx new "
     command += " --pem=\"{0}\" ".format(OWNER_PEMFILE)
     command += " --proxy=\"{0}\" ".format(PROXY_URL)
+    command += " --chain=\"{0}\" ".format(CHAIN_ID)
     command += " --data=\"{0}\" ".format(data)
 
     command += " --receiver {0} ".format(ESDT_ISSUE_ADDRESS)
@@ -44,32 +38,32 @@ def IssueTokenTransaction():
     command += "--recall-nonce "
     command += " --send "
 
-    # print("Command: {0}".format(command))
 
     process = subprocess.run(command, shell = True, stdout = subprocess.PIPE)
     json_tx = process.stdout
-
-    # print("json_tx: {0}".format(json_tx))
-    
     return json_tx
 
 
 def GetTransactionStatus():
     query = GATEWAY_URL + "/transaction/" + hash_value + "/status?withResults=true"
     request = requests.get(query)
-    
+
     return request
 
+def _pick_chain_id(network):
+    if network == 'devnet': return 'D'
+    if network == 'testnet': return 'T'
+    if network == 'mainnet': return '1'
+    print('Error wrong ntwork name (devnet, testnet, mainnet).')
 
-def main():
-    tx_output = IssueTokenTransaction()
-    print()
-    
+def main(token_name, token_ticker):
+    tx_output = IssueTokenTransaction(token_name, token_ticker)
+
     tx_output = tx_output.decode("UTF-8")
     tx_dict = ast.literal_eval(tx_output)
     global hash_value
     hash_value = tx_dict["hash"]
-    
+
     # waiting for the end of the transaction
     wait_seconds = 20
     print("Waiting for {0} seconds...".format(wait_seconds))
@@ -77,7 +71,7 @@ def main():
 
     req = GetTransactionStatus()
     req_dict = json.loads(req.text)
-    
+
     print("IssueTokenTransaction status : ", req_dict.get("data", {}).get("status"))
     print("Status: {0}".format(req_dict))
 
@@ -85,4 +79,22 @@ def main():
     # i.e. "SFC-55ba74"
 
 if __name__ == "__main__":
-    main()
+    # Initialize parser
+    parser = argparse.ArgumentParser()
+    # Adding optional argument
+    parser.add_argument("-net", "--network", help="Network name (mainnet, devnet, testnet)")
+    # See here for the format:
+    # https://docs.elrond.com/developers/esdt-tokens/#parameters-format
+    parser.add_argument("-tn", "--tokenname", help="Token name (no special characters or spaces in it)")
+    parser.add_argument("-tt", "--tokenticker", help="Token ticker (no special characters or spaces in it)")
+    # Read arguments from command line
+    args = parser.parse_args()
+
+    OWNER_PEMFILE = f"./wallet/{args.network}/{args.network}-wallet.pem"
+    PROXY_URL = f"https://{args.network}-api.elrond.com"
+    subdomain_gateway = args.network+'-' if args.network != 'mainnet' else ''
+
+    GATEWAY_URL = f"https://{subdomain_gateway}gateway.elrond.com"
+    CHAIN_ID = _pick_chain_id(args.network)
+
+    main(args.tokenname, args.tokenticker)

--- a/create-new-token.sh
+++ b/create-new-token.sh
@@ -1,16 +1,26 @@
 ##### - configuration - #####
-NETWORK_NAME="testnet" # devnet, testnet, mainnet
-PROXY=https://testnet-gateway.elrond.com
-CHAIN_ID="T"
+NETWORK_NAME="$1" # devnet, testnet, mainnet
+
+if [ $NETWORK_NAME = "devnet" ]; then
+    CHAIN_ID="D"
+elif [ $NETWORK_NAME = "testnet" ]; then
+    CHAIN_ID="T"
+elif [ $NETWORK_NAME = "mainnet" ]; then
+    CHAIN_ID="1"
+else
+    echo "Wrong NETWORK name, please choose betwee: devnet, testnet, mainnet !"
+    exit
+fi
+PROXY="https://${NETWORK_NAME}-gateway.elrond.com"
+DEPLOYER="./wallet/${NETWORK_NAME}/${NETWORK_NAME}-wallet.pem" # main actor pem file
 
 ESDT_ISSUE_ADDRESS=erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u
-DEPLOYER="./wallet/testnet/testnet-wallet.pem" # main actor pem file
 
-TOKEN_NAME="Sven"
-TOKEN_TICKER="SVEN"
+TOKEN_NAME="$2"
+TOKEN_TICKER="$3"
 
-TOKEN_NAME_HEX="$(echo -n ${TOKEN_NAME} | xxd -p -u | tr -d '\n')"
-TOKEN_TICKER_HEX="$(echo -n ${TOKEN_TICKER} | xxd -p -u | tr -d '\n')"
+TOKEN_NAME_HEX="$(echo "${TOKEN_NAME}" | xxd -p)"
+TOKEN_TICKER_HEX="$(echo "${TOKEN_TICKER}" | xxd -p)"
 
 # https://docs.elrond.com/developers/esdt-tokens/#issuance-of-fungible-esdt-tokens
 # initial supply: 1e24 wei - 1e6 $ESDT
@@ -19,8 +29,6 @@ DATA="issue@${TOKEN_NAME_HEX}@${TOKEN_TICKER_HEX}@d3c21bcecceda1000000@12@63616e
 
 ADDRESS=$(erdpy data load --partition ${NETWORK_NAME} --key=address)
 DEPLOY_TRANSACTION=$(erdpy data load --partition ${NETWORK_NAME} --key=deploy-transaction)
-
-echo "TEST A $1";
 
 issue_token() {
     echo "issuing token to ${NETWORK_NAME} ...";
@@ -37,4 +45,6 @@ issue_token() {
         --send || return
 }
 
-"$@"
+echo "Create EDST: ($1, $2)";
+
+issue_token


### PR DESCRIPTION
Hi, thanks for the repo it helped me a lot for understanding how `erdpy` was working!

Here is what I did:
- the problem for the devnet was a missing `CHAIN_ID` for python script or a wrong one in the SH script.
   - You can find here details about the network
      - https://gateway.elrond.com/network/config
      - https://devnet-gateway.elrond.com/network/config
      - https://testnet-gateway.elrond.com/network/config

```
➜ python3 create-new-token.py -net devnet -tn testcrtk -tt TCREATeTK        
INFO:accounts:Account.sync_nonce()
INFO:accounts:Account.sync_nonce() done: 2
INFO:transactions:Transaction.send: nonce=2
INFO:transactions:Hash: 872408dd35cefedf3d2a5212fc7ce50fe446233b18100fa0403192ab72b1f65e
INFO:utils:View this transaction in the Elrond Devnet Explorer: https://devnet-explorer.elrond.com/transactions/872408dd35cefedf3d2a5212fc7ce50fe446233b18100fa0403192ab72b1f65e
Waiting for 20 seconds...
IssueTokenTransaction status :  success
Status: {'data': {'status': 'success'}, 'error': '', 'code': 'successful'}
```

- make sure ticker in python script is upper case (we never know). 

- move the basic information as an argument of the script. 
    - I added a documentation for it.

Hope it will help others!